### PR TITLE
Update to zig 0.15.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,31 +8,36 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/zaudio.zig"),
     });
 
-    const miniaudio = b.addStaticLibrary(.{
-        .name = "miniaudio",
+    const miniaudio = b.addModule("miniaudio", .{
         .target = target,
         .optimize = optimize,
     });
 
-    b.installArtifact(miniaudio);
+    const miniaudio_lib = b.addLibrary(.{
+        .name = "miniaudio",
+        .root_module = miniaudio,
+        .linkage = .static,
+    });
+
+    b.installArtifact(miniaudio_lib);
 
     miniaudio.addIncludePath(b.path("libs/miniaudio"));
-    miniaudio.linkLibC();
+    miniaudio_lib.linkLibC();
 
     if (target.result.os.tag == .macos) {
         if (b.lazyDependency("system_sdk", .{})) |system_sdk| {
-            miniaudio.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
-            miniaudio.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
-            miniaudio.addLibraryPath(system_sdk.path("macos12/usr/lib"));
+            miniaudio_lib.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
+            miniaudio_lib.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
+            miniaudio_lib.addLibraryPath(system_sdk.path("macos12/usr/lib"));
         }
-        miniaudio.linkFramework("CoreAudio");
-        miniaudio.linkFramework("CoreFoundation");
-        miniaudio.linkFramework("AudioUnit");
-        miniaudio.linkFramework("AudioToolbox");
+        miniaudio_lib.linkFramework("CoreAudio");
+        miniaudio_lib.linkFramework("CoreFoundation");
+        miniaudio_lib.linkFramework("AudioUnit");
+        miniaudio_lib.linkFramework("AudioToolbox");
     } else if (target.result.os.tag == .linux) {
-        miniaudio.linkSystemLibrary("pthread");
-        miniaudio.linkSystemLibrary("m");
-        miniaudio.linkSystemLibrary("dl");
+        miniaudio_lib.linkSystemLibrary("pthread");
+        miniaudio_lib.linkSystemLibrary("m");
+        miniaudio_lib.linkSystemLibrary("dl");
     }
 
     miniaudio.addCSourceFile(.{
@@ -56,15 +61,19 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run zaudio tests");
 
-    const tests = b.addTest(.{
-        .name = "zaudio-tests",
+    const test_module = b.addModule("test", .{
         .root_source_file = b.path("src/zaudio.zig"),
         .target = target,
         .optimize = optimize,
     });
+
+    const tests = b.addTest(.{
+        .name = "zaudio-tests",
+        .root_module = test_module,
+    });
     b.installArtifact(tests);
 
-    tests.linkLibrary(miniaudio);
+    tests.linkLibrary(miniaudio_lib);
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zaudio,
     .fingerprint = 0xc5244e8cd6bdcffc, // Changing this has security and trust implications.
     .version = "0.11.0-dev",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -17,7 +17,7 @@ pub fn init(allocator: std.mem.Allocator) void {
 
     zaudioMemInit();
 }
-extern fn zaudioMemInit() callconv(.C) void;
+extern fn zaudioMemInit() callconv(.c) void;
 
 pub fn deinit() void {
     assert(mem_allocator != null);
@@ -392,15 +392,15 @@ pub const MonoExpansionMode = enum(u32) {
 pub const AllocationCallbacks = extern struct {
     user_data: ?*anyopaque,
 
-    onMalloc: ?*const fn (len: usize, user_data: ?*anyopaque) callconv(.C) ?*anyopaque,
+    onMalloc: ?*const fn (len: usize, user_data: ?*anyopaque) callconv(.c) ?*anyopaque,
 
     onRealloc: ?*const fn (
         ptr: ?*anyopaque,
         len: usize,
         user_data: ?*anyopaque,
-    ) callconv(.C) ?*anyopaque,
+    ) callconv(.c) ?*anyopaque,
 
-    onFree: ?*const fn (ptr: ?*anyopaque, user_data: ?*anyopaque) callconv(.C) void,
+    onFree: ?*const fn (ptr: ?*anyopaque, user_data: ?*anyopaque) callconv(.c) void,
 };
 
 pub const Bool32 = enum(u32) {
@@ -439,14 +439,14 @@ pub const Vfs = extern struct {
         size_in_bytes: usize,
     };
 
-    on_open: ?*const fn (self: *Vfs, file_path: [*:0]const u8, mode: OpenMode, handle: *FileHandle) callconv(.C) Result,
-    on_openw: ?*const fn (self: *Vfs, file_path: [*:0]const u32, mode: OpenMode, handle: *FileHandle) callconv(.C) Result,
-    on_close: ?*const fn (self: *Vfs, handle: FileHandle) callconv(.C) Result,
-    on_read: ?*const fn (self: *Vfs, handle: FileHandle, dst: [*]u8, size: usize, bytes_read: *usize) callconv(.C) Result,
-    on_write: ?*const fn (self: *Vfs, handle: FileHandle, src: [*]const u8, size: usize, bytes_written: *usize) callconv(.C) Result,
-    on_seek: ?*const fn (self: *Vfs, handle: FileHandle, offset: i64, origin: SeekOrigin) callconv(.C) Result,
-    on_tell: ?*const fn (self: *Vfs, handle: FileHandle, offset: *i64) callconv(.C) Result,
-    on_info: ?*const fn (self: *Vfs, handle: FileHandle, info: *FileInfo) callconv(.C) Result,
+    on_open: ?*const fn (self: *Vfs, file_path: [*:0]const u8, mode: OpenMode, handle: *FileHandle) callconv(.c) Result,
+    on_openw: ?*const fn (self: *Vfs, file_path: [*:0]const u32, mode: OpenMode, handle: *FileHandle) callconv(.c) Result,
+    on_close: ?*const fn (self: *Vfs, handle: FileHandle) callconv(.c) Result,
+    on_read: ?*const fn (self: *Vfs, handle: FileHandle, dst: [*]u8, size: usize, bytes_read: *usize) callconv(.c) Result,
+    on_write: ?*const fn (self: *Vfs, handle: FileHandle, src: [*]const u8, size: usize, bytes_written: *usize) callconv(.c) Result,
+    on_seek: ?*const fn (self: *Vfs, handle: FileHandle, offset: i64, origin: SeekOrigin) callconv(.c) Result,
+    on_tell: ?*const fn (self: *Vfs, handle: FileHandle, offset: *i64) callconv(.c) Result,
+    on_info: ?*const fn (self: *Vfs, handle: FileHandle, info: *FileInfo) callconv(.c) Result,
 };
 
 pub const Context = opaque {
@@ -469,7 +469,7 @@ pub const DataSourceBase = extern struct {
     loop_end_in_frames: u64,
     p_current: *DataSource,
     p_next: *DataSource,
-    onGetNext: ?*const fn (*DataSource) callconv(.C) void,
+    onGetNext: ?*const fn (*DataSource) callconv(.c) void,
     is_looping: Bool32,
 };
 
@@ -505,9 +505,9 @@ pub const DataSource = opaque {
             frames_out: ?*anyopaque,
             frame_count: u64,
             frames_read: *u64,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
-        onSeek: ?*const fn (ds: *DataSource, frame_index: u64) callconv(.C) Result,
+        onSeek: ?*const fn (ds: *DataSource, frame_index: u64) callconv(.c) Result,
 
         onGetDataFormat: ?*const fn (
             ds: *DataSource,
@@ -516,13 +516,13 @@ pub const DataSource = opaque {
             sample_rate: ?*u32,
             channel_map: ?[*]Channel,
             channel_map_cap: usize,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
-        onGetCursor: ?*const fn (ds: *DataSource, cursor: ?*u64) callconv(.C) Result,
+        onGetCursor: ?*const fn (ds: *DataSource, cursor: ?*u64) callconv(.c) Result,
 
-        onGetLength: ?*const fn (ds: *DataSource, length: ?*u64) callconv(.C) Result,
+        onGetLength: ?*const fn (ds: *DataSource, length: ?*u64) callconv(.c) Result,
 
-        onSetLooping: ?*const fn (ds: *DataSource, is_looping: Bool32) callconv(.C) Result,
+        onSetLooping: ?*const fn (ds: *DataSource, is_looping: Bool32) callconv(.c) Result,
 
         flags: Flags,
     };
@@ -763,13 +763,13 @@ pub const Node = opaque {
             frame_count_in: ?*u32,
             frames_out: *[*]f32,
             frame_count_out: *u32,
-        ) callconv(.C) void,
+        ) callconv(.c) void,
 
         onGetRequiredInputFrameCount: ?*const fn (
             node: *Node,
             output_frame_count: u32,
             input_frame_count: *u32,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
         input_bus_count: u8,
         output_bus_count: u8,
@@ -1721,13 +1721,13 @@ pub const Device = opaque {
         output: ?*anyopaque,
         input: ?*const anyopaque,
         frame_count: u32,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
     pub const NotificationProc = *const fn (
         *const anyopaque, // TODO: Should be `*const ma_device_notification`.
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
-    pub const StopProc = *const fn (device: *Device) callconv(.C) void;
+    pub const StopProc = *const fn (device: *Device) callconv(.c) void;
 
     pub const Id = extern union {
         wasapi: [64]i32,
@@ -1794,7 +1794,7 @@ pub const Engine = opaque {
         user_data: ?*anyopaque,
         frames_out: [*]f32,
         frame_count: u64,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
     pub fn create(config: ?Config) Error!*Engine {
         var handle: ?*Engine = null;
@@ -2423,7 +2423,7 @@ pub const Sound = opaque {
     pub const EndProc = *const fn (
         user_data: ?*anyopaque,
         sound: *Sound,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 };
 //--------------------------------------------------------------------------------------------------
 //
@@ -2710,15 +2710,15 @@ var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
 var mem_mutex: std.Thread.Mutex = .{};
 const mem_alignment = 16;
 
-extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque;
+extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
-fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
+fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
     mem_mutex.lock();
     defer mem_mutex.unlock();
 
     const mem = mem_allocator.?.alignedAlloc(
         u8,
-        mem_alignment,
+        .fromByteUnits(mem_alignment),
         size,
     ) catch @panic("zaudio: out of memory");
 
@@ -2727,9 +2727,9 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
     return mem.ptr;
 }
 
-extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque;
+extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
-fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
+fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
     mem_mutex.lock();
     defer mem_mutex.unlock();
 
@@ -2751,9 +2751,9 @@ fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*a
     return new_mem.ptr;
 }
 
-extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.C) void;
+extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void;
 
-fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
         mem_mutex.lock();
         defer mem_mutex.unlock();
@@ -2963,7 +2963,7 @@ test "zaudio.audio_buffer" {
     defer deinit();
 
     var samples = try std.ArrayList(f32).initCapacity(std.testing.allocator, 1000);
-    defer samples.deinit();
+    defer samples.deinit(std.testing.allocator);
 
     var prng = std.Random.DefaultPrng.init(0);
     const rand = prng.random();
@@ -2992,7 +2992,7 @@ test "zaudio.audio_buffer" {
     sound.setLooping(true);
     try sound.start();
 
-    std.time.sleep(1e8);
+    std.Thread.sleep(1e8);
 }
 
 test {


### PR DESCRIPTION
Fixes compilation (on Windows at least) with the just released zig 0.15.1

 - Removed use of previously deprecated APIs in build script (`addStaticLibrary` and `root_source_file`)
 - Removed use of deprecated alias `callconv(.C)` for `callconv(.c)`
 - Smaller changes: 
   - `alignedAlloc` takes a `std.mem.Alignment` instead of an arbitrary int
   - `std.time.sleep` -> `std.Thread.sleep`
   - std.ArrayList isn't managed by default anymore (`deinit` takes an allocator)

Only tested on Windows and in a very small program as I'm still in the process of migrating my own projects. 
Hope this is still useful!