### PR TITLE
[WIP and Discussion] Decoder Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Provided structs:
   - [x] `HishelfNode // High Shelf Filter`
   - [x] `DelayNode`
   - [x] custom nodes
+- [x] `Decoder` (missing methods)
+- [x] `DataConverter` 
 
 ## Getting started
 

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -683,7 +683,7 @@ void zaudioDataConverterConfigInit(
     ma_uint32 channelsOut, 
     ma_uint32 sampleRateIn, 
     ma_uint32 sampleRateOut,
-    ma_data_converter_config* out_config,
+    ma_data_converter_config* out_config
 ){
     assert(out_config != NULL);
     *out_config = ma_data_converter_config_init(formatIn, formatOut, channelsIn, channelsOut, sampleRateIn, sampleRateOut);
@@ -712,5 +712,18 @@ void zaudioDataConverterDestroy(
     s_mem.onFree(handle, s_mem.pUserData);
 }
 
+//--------------------------------------------------------------------------------------------------
+// ma_decoder 
+void ma_decoder_config_init(
+    ma_format outputFormat, 
+    ma_uint32 outputChannels, 
+    ma_uint32 outputSampleRate,
+    ma_decoder_config* out_config
+){
+    assert(out_config != NULL);
+    *out_config = ma_decoder_config_init(outputFormat, outputChannels, outputSampleRate);
+}
+
+// There are more variants in decoder than all other types, 
 
 //--------------------------------------------------------------------------------------------------

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -689,6 +689,11 @@ void zaudioDataConverterConfigInit(
     *out_config = ma_data_converter_config_init(formatIn, formatOut, channelsIn, channelsOut, sampleRateIn, sampleRateOut);
 }
 
+void zaudioDataConverterConfigInitDefault(ma_data_converter_config* out_config){
+    assert(out_config != NULL);
+    *out_config = ma_data_converter_config_init_default();
+}
+
 // ma_data_converter
 ma_result zaudioDataConverterCreate(
     ma_data_converter_config* config,

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -718,7 +718,7 @@ void zaudioDataConverterDestroy(
 }
 
 //--------------------------------------------------------------------------------------------------
-// ma_decoder zaudioDataConverterConfigInit
+// ma_decoder zaudioDecoderConfigInit
 void zaudioDecoderConfigInit(
     ma_format outputFormat, 
     ma_uint32 outputChannels, 
@@ -800,7 +800,7 @@ ma_result zaudioDecoderCreateFromFile(
     return res;      
 }
 
-ma_result zaudioDecoderDestroy(
+void zaudioDecoderDestroy(
     ma_decoder* handle
 ){
     assert(handle != NULL);

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -675,3 +675,42 @@ void WA_ma_sound_get_velocity(const ma_sound* sound, ma_vec3f* vout) {
     *vout = ma_sound_get_velocity(sound);
 }
 //--------------------------------------------------------------------------------------------------
+// ma_data_converter, required for decoder
+void zaudioDataConverterConfigInit(
+    ma_format formatIn, 
+    ma_format formatOut, 
+    ma_uint32 channelsIn, 
+    ma_uint32 channelsOut, 
+    ma_uint32 sampleRateIn, 
+    ma_uint32 sampleRateOut,
+    ma_data_converter_config* out_config,
+){
+    assert(out_config != NULL);
+    *out_config = ma_data_converter_config_init(formatIn, formatOut, channelsIn, channelsOut, sampleRateIn, sampleRateOut);
+}
+
+// ma_data_converter
+ma_result zaudioDataConverterCreate(
+    ma_data_converter_config* config,
+    ma_data_converter** out_handle
+){
+    assert(config != NULL && out_handle != NULL);
+    *out_handle = s_mem.onMalloc(sizeof(ma_data_converter), s_mem.pUserData);
+    ma_result res = ma_data_converter_init(config, &s_mem, *out_handle);
+    if (res != MA_SUCCESS){
+        s_mem.onFree(*out_handle, s_mem.pUserData);
+        *out_handle = NULL;
+    }
+    return res;
+}
+
+void zaudioDataConverterDestroy(
+    ma_data_converter* handle
+){
+    assert(handle != NULL);
+    ma_data_converter_uninit(handle, &s_mem);
+    s_mem.onFree(handle, s_mem.pUserData);
+}
+
+
+//--------------------------------------------------------------------------------------------------

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -736,7 +736,7 @@ ma_result zaudioDecoderCreate(
 ){
     assert(user_data!= NULL && config != NULL && out_handle != NULL);
     *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
-    ma_result res = ma_decoder_init(on_read, on_seek, user_data, config, out_handle);
+    ma_result res = ma_decoder_init(on_read, on_seek, user_data, config, *out_handle);
     if (res != MA_SUCCESS){
         s_mem.onFree(*out_handle, s_mem.pUserData);
         *out_handle = NULL;
@@ -750,9 +750,9 @@ ma_result zaudioDecoderCreateFromMemory(
     const ma_decoder_config* config, 
     ma_decoder** out_handle
 ){
-    assert(data != NULL && config != NULL && decoder != NULL);
+    assert(data != NULL && config != NULL && out_handle != NULL);
     *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
-    ma_result res = ma_decoder_init_memory(data, data_size, config, out_handle);
+    ma_result res = ma_decoder_init_memory(data, data_size, config, *out_handle);
     if (res != MA_SUCCESS){
         s_mem.onFree(*out_handle, s_mem.pUserData);
         *out_handle = NULL;
@@ -768,7 +768,7 @@ ma_result zaudioDecoderCreateFromVfs(
 ){
     assert(vfs != NULL && file_path != NULL && config != NULL && out_handle != NULL);
     *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
-    ma_result res = ma_decoder_init_vfs(vfs, file_path, config, out_handle);
+    ma_result res = ma_decoder_init_vfs(vfs, file_path, config, *out_handle);
     if (res != MA_SUCCESS){
         s_mem.onFree(*out_handle, s_mem.pUserData);
         *out_handle = NULL;
@@ -781,9 +781,9 @@ ma_result zaudioDecoderCreateFromFile(
     const ma_decoder_config* config, 
     ma_decoder** out_handle
 ){
-    assert(file_path != NULL && config != NULL, out_handle != NULL);
+    assert(file_path != NULL && config != NULL && out_handle != NULL);
     *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
-    ma_result res = ma_decoder_init_file(file_path, config, out_handle);
+    ma_result res = ma_decoder_init_file(file_path, config, *out_handle);
     if (res != MA_SUCCESS){
         s_mem.onFree(*out_handle, s_mem.pUserData);
         *out_handle = NULL;
@@ -795,7 +795,7 @@ ma_result zaudioDecoderDestroy(
     ma_decoder* handle
 ){
     assert(handle != NULL);
-    ma_data_converter_uninit(handle, &s_mem);
+    ma_decoder_uninit(handle);
     s_mem.onFree(handle, s_mem.pUserData);
 }
 

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -713,8 +713,8 @@ void zaudioDataConverterDestroy(
 }
 
 //--------------------------------------------------------------------------------------------------
-// ma_decoder 
-void ma_decoder_config_init(
+// ma_decoder zaudioDataConverterConfigInit
+void zaudioDecoderConfigInit(
     ma_format outputFormat, 
     ma_uint32 outputChannels, 
     ma_uint32 outputSampleRate,
@@ -760,7 +760,7 @@ ma_result zaudioDecoderCreateFromMemory(
     return res;       
 }
 
-ma_result zaudioDecoderCreateVfs(
+ma_result zaudioDecoderCreateFromVfs(
     ma_vfs* vfs, 
     const char* file_path, 
     const ma_decoder_config* config, 
@@ -776,7 +776,7 @@ ma_result zaudioDecoderCreateVfs(
     return res;     
 }
 
-ma_result zaudioDecoderFile(
+ma_result zaudioDecoderCreateFromFile(
     const char* file_path, 
     const ma_decoder_config* config, 
     ma_decoder** out_handle
@@ -789,6 +789,14 @@ ma_result zaudioDecoderFile(
         *out_handle = NULL;
     }
     return res;      
+}
+
+ma_result zaudioDecoderDestroy(
+    ma_decoder* handle
+){
+    assert(handle != NULL);
+    ma_data_converter_uninit(handle, &s_mem);
+    s_mem.onFree(handle, s_mem.pUserData);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -724,6 +724,10 @@ void zaudioDecoderConfigInit(
     *out_config = ma_decoder_config_init(outputFormat, outputChannels, outputSampleRate);
 }
 
+void zaudioDecoderConfigInitDefault(ma_decoder_config* out_config){
+    *out_config = ma_decoder_config_init_default();
+}
+
 // There are more variants in decoder than all other types, but I will only handle the non-w type
 // since the other type with the similar file access method don't include such type as well
 // unless there is a good solution for wchar_t.

--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -724,6 +724,71 @@ void ma_decoder_config_init(
     *out_config = ma_decoder_config_init(outputFormat, outputChannels, outputSampleRate);
 }
 
-// There are more variants in decoder than all other types, 
+// There are more variants in decoder than all other types, but I will only handle the non-w type
+// since the other type with the similar file access method don't include such type as well
+// unless there is a good solution for wchar_t.
+ma_result zaudioDecoderCreate(
+    ma_decoder_read_proc on_read, 
+    ma_decoder_seek_proc on_seek, 
+    void* user_data, 
+    const ma_decoder_config* config, 
+    ma_decoder** out_handle
+){
+    assert(user_data!= NULL && config != NULL && out_handle != NULL);
+    *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
+    ma_result res = ma_decoder_init(on_read, on_seek, user_data, config, out_handle);
+    if (res != MA_SUCCESS){
+        s_mem.onFree(*out_handle, s_mem.pUserData);
+        *out_handle = NULL;
+    }
+    return res;    
+}
+
+ma_result zaudioDecoderCreateFromMemory(
+    const void* data, 
+    size_t data_size, 
+    const ma_decoder_config* config, 
+    ma_decoder** out_handle
+){
+    assert(data != NULL && config != NULL && decoder != NULL);
+    *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
+    ma_result res = ma_decoder_init_memory(data, data_size, config, out_handle);
+    if (res != MA_SUCCESS){
+        s_mem.onFree(*out_handle, s_mem.pUserData);
+        *out_handle = NULL;
+    }
+    return res;       
+}
+
+ma_result zaudioDecoderCreateVfs(
+    ma_vfs* vfs, 
+    const char* file_path, 
+    const ma_decoder_config* config, 
+    ma_decoder** out_handle
+){
+    assert(vfs != NULL && file_path != NULL && config != NULL && out_handle != NULL);
+    *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
+    ma_result res = ma_decoder_init_vfs(vfs, file_path, config, out_handle);
+    if (res != MA_SUCCESS){
+        s_mem.onFree(*out_handle, s_mem.pUserData);
+        *out_handle = NULL;
+    }
+    return res;     
+}
+
+ma_result zaudioDecoderFile(
+    const char* file_path, 
+    const ma_decoder_config* config, 
+    ma_decoder** out_handle
+){
+    assert(file_path != NULL && config != NULL, out_handle != NULL);
+    *out_handle = s_mem.onMalloc(sizeof(ma_decoder), s_mem.pUserData);
+    ma_result res = ma_decoder_init_file(file_path, config, out_handle);
+    if (res != MA_SUCCESS){
+        s_mem.onFree(*out_handle, s_mem.pUserData);
+        *out_handle = NULL;
+    }
+    return res;      
+}
 
 //--------------------------------------------------------------------------------------------------

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -874,6 +874,43 @@ pub const DataConverter = opaque {
         channel_weighs_io_ptr: [*][*]f32, // [in][out]. Only used when mixingMode is set to ma_channel_mix_mode_custom_weights.
         allow_dynamic_sample_rate: u32,
         resampling: Resampler.Config,
+
+        pub fn initDefault() Config {
+            var config: Config = undefined;
+            zaudioDataConverterConfigInitDefault(&config);
+            return config;
+        }
+        extern fn zaudioDataConverterConfigInitDefault(out_config: *Config) void;
+
+        pub fn init(
+            format_in: Format,
+            format_out: Format,
+            channels_in: u32,
+            channels_out: u32,
+            sample_rate_in: u32,
+            sample_rate_out: u32,
+        ) Config {
+            var config: Config = undefined;
+            zaudioDataConverterConfigInit(
+                format_in,
+                format_out,
+                channels_in,
+                channels_out,
+                sample_rate_in,
+                sample_rate_out,
+                &config,
+            );
+            return config;
+        }
+        extern fn zaudioDataConverterConfigInit(
+            format_in: Format,
+            format_out: Format,
+            channels_in: u32,
+            channels_out: u32,
+            sample_rate_in: u32,
+            sample_rate_out: u32,
+            out_config: *Config,
+        ) void;
     };
 };
 

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -17,7 +17,7 @@ pub fn init(allocator: std.mem.Allocator) void {
 
     zaudioMemInit();
 }
-extern fn zaudioMemInit() callconv(.C) void;
+extern fn zaudioMemInit() callconv(.c) void;
 
 pub fn deinit() void {
     assert(mem_allocator != null);
@@ -406,15 +406,15 @@ pub const MonoExpansionMode = enum(u32) {
 pub const AllocationCallbacks = extern struct {
     user_data: ?*anyopaque,
 
-    onMalloc: ?*const fn (len: usize, user_data: ?*anyopaque) callconv(.C) ?*anyopaque,
+    onMalloc: ?*const fn (len: usize, user_data: ?*anyopaque) callconv(.c) ?*anyopaque,
 
     onRealloc: ?*const fn (
         ptr: ?*anyopaque,
         len: usize,
         user_data: ?*anyopaque,
-    ) callconv(.C) ?*anyopaque,
+    ) callconv(.c) ?*anyopaque,
 
-    onFree: ?*const fn (ptr: ?*anyopaque, user_data: ?*anyopaque) callconv(.C) void,
+    onFree: ?*const fn (ptr: ?*anyopaque, user_data: ?*anyopaque) callconv(.c) void,
 };
 
 pub const Bool32 = enum(u32) {
@@ -453,21 +453,21 @@ pub const Vfs = extern struct {
         size_in_bytes: usize,
     };
 
-    on_open: ?*const fn (self: *Vfs, file_path: [*:0]const u8, mode: OpenMode, handle: *FileHandle) callconv(.C) Result,
-    on_openw: ?*const fn (self: *Vfs, file_path: [*:0]const u32, mode: OpenMode, handle: *FileHandle) callconv(.C) Result,
-    on_close: ?*const fn (self: *Vfs, handle: FileHandle) callconv(.C) Result,
-    on_read: ?*const fn (self: *Vfs, handle: FileHandle, dst: [*]u8, size: usize, bytes_read: *usize) callconv(.C) Result,
-    on_write: ?*const fn (self: *Vfs, handle: FileHandle, src: [*]const u8, size: usize, bytes_written: *usize) callconv(.C) Result,
-    on_seek: ?*const fn (self: *Vfs, handle: FileHandle, offset: i64, origin: SeekOrigin) callconv(.C) Result,
-    on_tell: ?*const fn (self: *Vfs, handle: FileHandle, offset: *i64) callconv(.C) Result,
-    on_info: ?*const fn (self: *Vfs, handle: FileHandle, info: *FileInfo) callconv(.C) Result,
+    on_open: ?*const fn (self: *Vfs, file_path: [*:0]const u8, mode: OpenMode, handle: *FileHandle) callconv(.c) Result,
+    on_openw: ?*const fn (self: *Vfs, file_path: [*:0]const u32, mode: OpenMode, handle: *FileHandle) callconv(.c) Result,
+    on_close: ?*const fn (self: *Vfs, handle: FileHandle) callconv(.c) Result,
+    on_read: ?*const fn (self: *Vfs, handle: FileHandle, dst: [*]u8, size: usize, bytes_read: *usize) callconv(.c) Result,
+    on_write: ?*const fn (self: *Vfs, handle: FileHandle, src: [*]const u8, size: usize, bytes_written: *usize) callconv(.c) Result,
+    on_seek: ?*const fn (self: *Vfs, handle: FileHandle, offset: i64, origin: SeekOrigin) callconv(.c) Result,
+    on_tell: ?*const fn (self: *Vfs, handle: FileHandle, offset: *i64) callconv(.c) Result,
+    on_info: ?*const fn (self: *Vfs, handle: FileHandle, info: *FileInfo) callconv(.c) Result,
 };
 
 // these functions were originally located under vfs, but they seems to have no correlation to the type,
 // while decoder require such type in order to make it work, so I will temporary locate these functions in here:
-pub const readProc = *const fn (user_data: ?*anyopaque, buffer_out: ?*anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.C) Result;
-pub const seekProc = *const fn (user_data: ?*anyopaque, offset: i64, origin: Vfs.SeekOrigin) callconv(.C) Result;
-pub const tellProc = *const fn (user_data: ?*anyopaque, cursor: ?*i64) callconv(.C) Result;
+pub const readProc = *const fn (user_data: ?*anyopaque, buffer_out: ?*anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.c) Result;
+pub const seekProc = *const fn (user_data: ?*anyopaque, offset: i64, origin: Vfs.SeekOrigin) callconv(.c) Result;
+pub const tellProc = *const fn (user_data: ?*anyopaque, cursor: ?*i64) callconv(.c) Result;
 
 pub const Context = opaque {
     // TODO: Add methods.
@@ -489,7 +489,7 @@ pub const DataSourceBase = extern struct {
     loop_end_in_frames: u64,
     p_current: *DataSource,
     p_next: *DataSource,
-    onGetNext: ?*const fn (*DataSource) callconv(.C) void,
+    onGetNext: ?*const fn (*DataSource) callconv(.c) void,
     is_looping: Bool32,
 };
 
@@ -525,9 +525,9 @@ pub const DataSource = opaque {
             frames_out: ?*anyopaque,
             frame_count: u64,
             frames_read: *u64,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
-        onSeek: ?*const fn (ds: *DataSource, frame_index: u64) callconv(.C) Result,
+        onSeek: ?*const fn (ds: *DataSource, frame_index: u64) callconv(.c) Result,
 
         onGetDataFormat: ?*const fn (
             ds: *DataSource,
@@ -536,13 +536,13 @@ pub const DataSource = opaque {
             sample_rate: ?*u32,
             channel_map: ?[*]Channel,
             channel_map_cap: usize,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
-        onGetCursor: ?*const fn (ds: *DataSource, cursor: ?*u64) callconv(.C) Result,
+        onGetCursor: ?*const fn (ds: *DataSource, cursor: ?*u64) callconv(.c) Result,
 
-        onGetLength: ?*const fn (ds: *DataSource, length: ?*u64) callconv(.C) Result,
+        onGetLength: ?*const fn (ds: *DataSource, length: ?*u64) callconv(.c) Result,
 
-        onSetLooping: ?*const fn (ds: *DataSource, is_looping: Bool32) callconv(.C) Result,
+        onSetLooping: ?*const fn (ds: *DataSource, is_looping: Bool32) callconv(.c) Result,
 
         flags: Flags,
     };
@@ -824,15 +824,15 @@ pub const DataConverter = opaque {
     }
     extern fn ma_data_converter_get_expected_output_frame_count(converter: *DataConverter, input_frame_count: u64, output_frame_count: *u64) Result;
 
-    pub fn getInputChannelMap(converter: *DataConverter, channel_map: *Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_data_converter_get_input_channel_map(converter, channel_map, channel_map_cap));
+    pub fn getInputChannelMap(converter: *DataConverter, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
+        try maybeError(ma_data_converter_get_input_channel_map(converter, channel_map.ptr, channel_map_cap));
     }
-    extern fn ma_data_converter_get_input_channel_map(converter: *DataConverter, channel_map: *Channel, channel_map_cap: usize) Result;
+    extern fn ma_data_converter_get_input_channel_map(converter: *DataConverter, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
-    pub fn getOutputChannelMap(converter: *DataConverter, channel_map: *Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_data_converter_get_output_channel_map(converter, channel_map, channel_map_cap));
+    pub fn getOutputChannelMap(converter: *DataConverter, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
+        try maybeError(ma_data_converter_get_output_channel_map(converter, channel_map.ptr, channel_map_cap));
     }
-    extern fn ma_data_converter_get_output_channel_map(converter: *DataConverter, channel_map: *Channel, channel_map_cap: usize) Result;
+    extern fn ma_data_converter_get_output_channel_map(converter: *DataConverter, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
     pub fn reset(converter: *DataConverter) Error!void {
         try maybeError(ma_data_converter_reset(converter));
@@ -855,8 +855,8 @@ pub const DataConverter = opaque {
         channels_out: u32,
         sample_rate_in: u32,
         sample_rate_out: u32,
-        channel_map_in: *Channel,
-        channel_map_out: *Channel,
+        channel_map_in: ?[*]Channel,
+        channel_map_out: ?[*]Channel,
         dither_mode: DitherMode,
         channel_mix_mode: ChannelMixMode,
         calculate_LFE_from_spatial_channels: u32,
@@ -872,6 +872,13 @@ pub const DataConverter = opaque {
 //
 //--------------------------------------------------------------------------------------------------
 pub const Decoder = opaque {
+    pub fn asDataSource(handle: *const Decoder) *const DataSource {
+        return @as(*const DataSource, @ptrCast(handle));
+    }
+    pub fn asDataSourceMut(handle: *Decoder) *DataSource {
+        return @as(*DataSource, @ptrCast(handle));
+    }
+
     pub const destroy = zaudioDecoderDestroy;
     extern fn zaudioDecoderDestroy(handle: *Decoder) void;
 
@@ -916,10 +923,10 @@ pub const Decoder = opaque {
     }
     extern fn ma_decoder_seek_to_pcm_frame(decoder: *Decoder, frame_index: u64) Result;
 
-    pub fn getDataFormat(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: [*]Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_decoder_get_data_format(decoder, format, channels, sample_rate, channel_map, channel_map_cap));
+    pub fn getDataFormat(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
+        try maybeError(ma_decoder_get_data_format(decoder, format, channels, sample_rate, channel_map.ptr, channel_map_cap));
     }
-    extern fn ma_decoder_get_data_format(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: [*]Channel, channel_map_cap: usize) Result;
+    extern fn ma_decoder_get_data_format(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
     pub fn getCursorInPCMFrames(decoder: *Decoder) Error!u64 {
         var cursor: u64 = undefined;
@@ -952,7 +959,7 @@ pub const Decoder = opaque {
             config: *const BackendConfig,
             allocation_callbacks: AllocationCallbacks,
             backend: **DataSource,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
         onInitFile: ?*const fn (
             user_data: *anyopaque,
@@ -960,7 +967,7 @@ pub const Decoder = opaque {
             config: BackendConfig,
             allocation_callbacks: AllocationCallbacks,
             backend: **DataSource,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
         onInitMemory: ?*const fn (
             user_data: *anyopaque,
@@ -969,20 +976,20 @@ pub const Decoder = opaque {
             config: BackendConfig,
             allocation_callbacks: AllocationCallbacks,
             backend: **DataSource,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
         onUninit: ?*const fn (
             user_data: *anyopaque,
             backend: *DataSource,
             allocation_callbacks: AllocationCallbacks,
-        ) callconv(.C) void,
+        ) callconv(.c) void,
     };
 
     pub const Config = extern struct {
         format: Format,
         channels: u32,
         sample_rate: u32,
-        channel_map: *Channel,
+        channel_map: ?[*]Channel,
         channel_mix_mode: ChannelMixMode,
         dither_mode: DitherMode,
         resampling: Resampler.Config,
@@ -991,7 +998,7 @@ pub const Decoder = opaque {
         seek_point_count: u32,
         custom_backend_vtable: ?*?*VTable,
         custom_backend_count: u32,
-        custom_backend_user_data: *anyopaque,
+        custom_backend_user_data: ?*anyopaque,
 
         pub fn initDefault() Config {
             var config: Config = undefined;
@@ -1014,7 +1021,7 @@ pub const Decoder = opaque {
     };
 };
 
-pub const decoderReadProc = fn (decoder: *Decoder, buffer_out: *anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.C) Result;
+pub const decoderReadProc = fn (decoder: *Decoder, buffer_out: *anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.c) Result;
 pub const decoderSeekProc = fn (decoder: *Decoder, byte_offset: i64, origin: Vfs.SeekOrigin) Result;
 pub const decoderTellProc = fn (decoder: *Decoder, cursor: *i64) Result;
 
@@ -1066,13 +1073,13 @@ pub const Node = opaque {
             frame_count_in: ?*u32,
             frames_out: *[*]f32,
             frame_count_out: *u32,
-        ) callconv(.C) void,
+        ) callconv(.c) void,
 
         onGetRequiredInputFrameCount: ?*const fn (
             node: *Node,
             output_frame_count: u32,
             input_frame_count: *u32,
-        ) callconv(.C) Result,
+        ) callconv(.c) Result,
 
         input_bus_count: u8,
         output_bus_count: u8,
@@ -2024,13 +2031,13 @@ pub const Device = opaque {
         output: ?*anyopaque,
         input: ?*const anyopaque,
         frame_count: u32,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
     pub const NotificationProc = *const fn (
         *const anyopaque, // TODO: Should be `*const ma_device_notification`.
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
-    pub const StopProc = *const fn (device: *Device) callconv(.C) void;
+    pub const StopProc = *const fn (device: *Device) callconv(.c) void;
 
     pub const Id = extern union {
         wasapi: [64]i32,
@@ -2097,7 +2104,7 @@ pub const Engine = opaque {
         user_data: ?*anyopaque,
         frames_out: [*]f32,
         frame_count: u64,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 
     pub fn create(config: ?Config) Error!*Engine {
         var handle: ?*Engine = null;
@@ -2726,7 +2733,7 @@ pub const Sound = opaque {
     pub const EndProc = *const fn (
         user_data: ?*anyopaque,
         sound: *Sound,
-    ) callconv(.C) void;
+    ) callconv(.c) void;
 };
 //--------------------------------------------------------------------------------------------------
 //
@@ -3013,15 +3020,15 @@ var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
 var mem_mutex: std.Thread.Mutex = .{};
 const mem_alignment = 16;
 
-extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque;
+extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
-fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
+fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
     mem_mutex.lock();
     defer mem_mutex.unlock();
 
     const mem = mem_allocator.?.alignedAlloc(
         u8,
-        mem_alignment,
+        .fromByteUnits(mem_alignment),
         size,
     ) catch @panic("zaudio: out of memory");
 
@@ -3030,9 +3037,9 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
     return mem.ptr;
 }
 
-extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque;
+extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
-fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*anyopaque {
+fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
     mem_mutex.lock();
     defer mem_mutex.unlock();
 
@@ -3054,9 +3061,9 @@ fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.C) ?*a
     return new_mem.ptr;
 }
 
-extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.C) void;
+extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void;
 
-fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.C) void {
+fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
         mem_mutex.lock();
         defer mem_mutex.unlock();
@@ -3266,7 +3273,7 @@ test "zaudio.audio_buffer" {
     defer deinit();
 
     var samples = try std.ArrayList(f32).initCapacity(std.testing.allocator, 1000);
-    defer samples.deinit();
+    defer samples.deinit(std.testing.allocator);
 
     var prng = std.Random.DefaultPrng.init(0);
     const rand = prng.random();
@@ -3295,7 +3302,7 @@ test "zaudio.audio_buffer" {
     sound.setLooping(true);
     try sound.start();
 
-    std.time.sleep(1e8);
+    std.Thread.sleep(1e8);
 }
 
 test {

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -937,7 +937,7 @@ pub const Decoder = opaque {
         try maybeError(zaudioDecoderCreate(decoder_on_read, decoder_on_seek, user_data, &config, &handle));
         return handle.?;
     }
-    extern fn zaudioDecoderCreate(on_read: decoderReadProc, on_seek: decoderSeekProc, user_data: *anyopaque, config: *const Config, out_handle: *?*?Decoder) Result;
+    extern fn zaudioDecoderCreate(on_read: decoderReadProc, on_seek: decoderSeekProc, user_data: *anyopaque, config: *const Config, out_handle: ?*?*Decoder) Result;
 
     pub fn createFromMemory(data: ?*const anyopaque, data_size: usize, config: Config) Error!*Decoder {
         var handle: ?*Decoder = null;
@@ -1083,8 +1083,8 @@ pub const Decoder = opaque {
 };
 
 pub const decoderReadProc = fn (decoder: *Decoder, buffer_out: *anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.c) Result;
-pub const decoderSeekProc = fn (decoder: *Decoder, byte_offset: i64, origin: Vfs.SeekOrigin) Result;
-pub const decoderTellProc = fn (decoder: *Decoder, cursor: *i64) Result;
+pub const decoderSeekProc = fn (decoder: *Decoder, byte_offset: i64, origin: Vfs.SeekOrigin) callconv(.c) Result;
+pub const decoderTellProc = fn (decoder: *Decoder, cursor: *i64) callconv(.c) Result;
 
 //--------------------------------------------------------------------------------------------------
 //

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -906,12 +906,12 @@ pub const Decoder = opaque {
     extern fn zaudioDecoderCreateFromFile(file_path: [*:0]const u8, config: *const Config, out_handle: ?*?*Decoder) Result;
 
     // The remaing related functions for manipulate the samples:
-    pub fn readPCMFrame(decoder: *Decoder, frame_out: *anyopaque, frames_count: u64, frames_read: *u64) Error!void {
+    pub fn readPCMFrames(decoder: *Decoder, frame_out: *anyopaque, frames_count: u64, frames_read: ?*u64) Error!void {
         try maybeError(ma_decoder_read_pcm_frames(decoder, frame_out, frames_count, frames_read));
     }
     extern fn ma_decoder_read_pcm_frames(decoder: *Decoder, frame_out: *anyopaque, frames_count: u64, frames_read: ?*u64) Result;
 
-    pub fn seekToPCMFrame(decoder: *Decoder, frame_index: u64) Error!void {
+    pub fn seekToPCMFrames(decoder: *Decoder, frame_index: u64) Error!void {
         try maybeError(ma_decoder_seek_to_pcm_frame(decoder, frame_index));
     }
     extern fn ma_decoder_seek_to_pcm_frame(decoder: *Decoder, frame_index: u64) Result;
@@ -992,6 +992,20 @@ pub const Decoder = opaque {
         custom_backend_vtable: ?*?*VTable,
         custom_backend_count: u32,
         custom_backend_user_data: *anyopaque,
+
+        pub fn initDefault() Config {
+            var config: Config = undefined;
+            zaudioDecoderConfigInitDefault(&config);
+            return config;
+        }
+        extern fn zaudioDecoderConfigInitDefault(out_config: *Config) void;
+
+        pub fn init(output_format: Format, output_channels: u32, output_sample_rate: u32) Config {
+            var config: Config = undefined;
+            zaudioDecoderConfigInit(output_format, output_channels, output_sample_rate, &config);
+            return config;
+        }
+        extern fn zaudioDecoderConfigInit(output_format: Format, output_channels: u32, output_sample_rate: u32, out_config: *Config) void;
     };
 
     pub const BackendConfig = extern struct {

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -824,13 +824,24 @@ pub const DataConverter = opaque {
     }
     extern fn ma_data_converter_get_expected_output_frame_count(converter: *DataConverter, input_frame_count: u64, output_frame_count: *u64) Result;
 
-    pub fn getInputChannelMap(converter: *DataConverter, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_data_converter_get_input_channel_map(converter, channel_map.ptr, channel_map_cap));
+    pub fn getInputChannelMap(converter: *DataConverter, channel_map: ?[]Channel) Error!void {
+        try maybeError(ma_data_converter_get_input_channel_map(
+            converter,
+            if (channel_map) |chm| chm.ptr else null,
+            if (channel_map) |chm| chm.len else 0,
+        ));
     }
     extern fn ma_data_converter_get_input_channel_map(converter: *DataConverter, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
-    pub fn getOutputChannelMap(converter: *DataConverter, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_data_converter_get_output_channel_map(converter, channel_map.ptr, channel_map_cap));
+    pub fn getOutputChannelMap(
+        converter: *DataConverter,
+        channel_map: ?[]Channel,
+    ) Error!void {
+        try maybeError(ma_data_converter_get_output_channel_map(
+            converter,
+            if (channel_map) |chm| chm.ptr else null,
+            if (channel_map) |chm| chm.len else 0,
+        ));
     }
     extern fn ma_data_converter_get_output_channel_map(converter: *DataConverter, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
@@ -923,10 +934,23 @@ pub const Decoder = opaque {
     }
     extern fn ma_decoder_seek_to_pcm_frame(decoder: *Decoder, frame_index: u64) Result;
 
-    pub fn getDataFormat(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: ?[]Channel, channel_map_cap: usize) Error!void {
-        try maybeError(ma_decoder_get_data_format(decoder, format, channels, sample_rate, channel_map.ptr, channel_map_cap));
+    pub fn getDataFormat(
+        decoder: *const Decoder,
+        format: ?*Format,
+        channels: ?*u32,
+        sample_rate: ?*u32,
+        channel_map: ?[]Channel,
+    ) Error!void {
+        try maybeError(ma_decoder_get_data_format(
+            decoder,
+            format,
+            channels,
+            sample_rate,
+            if (channel_map) |chm| chm.ptr else null,
+            if (channel_map) |chm| chm.len else 0,
+        ));
     }
-    extern fn ma_decoder_get_data_format(decoder: *Decoder, format: *Format, channels: *u32, sample_rate: *u32, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
+    extern fn ma_decoder_get_data_format(decoder: *const Decoder, format: ?*Format, channels: ?*u32, sample_rate: ?*u32, channel_map: ?[*]Channel, channel_map_cap: usize) Result;
 
     pub fn getCursorInPCMFrames(decoder: *Decoder) Error!u64 {
         var cursor: u64 = undefined;

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -463,8 +463,6 @@ pub const Vfs = extern struct {
     on_info: ?*const fn (self: *Vfs, handle: FileHandle, info: *FileInfo) callconv(.c) Result,
 };
 
-// these functions were originally located under vfs, but they seems to have no correlation to the type,
-// while decoder require such type in order to make it work, so I will temporary locate these functions in here:
 pub const readProc = *const fn (user_data: ?*anyopaque, buffer_out: ?*anyopaque, bytes_to_read: usize, bytes_read: *usize) callconv(.c) Result;
 pub const seekProc = *const fn (user_data: ?*anyopaque, offset: i64, origin: Vfs.SeekOrigin) callconv(.c) Result;
 pub const tellProc = *const fn (user_data: ?*anyopaque, cursor: ?*i64) callconv(.c) Result;
@@ -930,8 +928,6 @@ pub const Decoder = opaque {
     pub const destroy = zaudioDecoderDestroy;
     extern fn zaudioDecoderDestroy(handle: *Decoder) void;
 
-    // here are the init functions, but after observed other examples
-    // I will skip the _w variant until there is a solution to handle wchar_t
     pub fn create(decoder_on_read: decoderReadProc, decoder_on_seek: decoderSeekProc, user_data: *anyopaque, config: Config) Error!*Decoder {
         var handle: ?*Decoder = null;
         try maybeError(zaudioDecoderCreate(decoder_on_read, decoder_on_seek, user_data, &config, &handle));
@@ -960,7 +956,6 @@ pub const Decoder = opaque {
     }
     extern fn zaudioDecoderCreateFromFile(file_path: [*:0]const u8, config: *const Config, out_handle: ?*?*Decoder) Result;
 
-    // The remaing related functions for manipulate the samples:
     pub fn readPCMFrames(decoder: *Decoder, frame_out: *anyopaque, frames_count: u64, frames_read: ?*u64) Error!void {
         try maybeError(ma_decoder_read_pcm_frames(decoder, frame_out, frames_count, frames_read));
     }


### PR DESCRIPTION
As mentioned in [this issues](https://github.com/zig-gamedev/zaudio/issues/8), I was working on the decoder type so that we can process audio at low level which is useful for custom decoders or more complicated audio applications due to the ability of access the output buffer directly with the function "readPCMFrames()" suggested by the [official miniaudio documentation](https://miniaud.io/docs/examples/simple_playback.html). My Resampler_Decoder_Prototype branch has a working prototype currently.

The current version is subjected to change because I have some questions related to the my current implementation and the callback function:

Since the current callback function from device use `callconv(.c) void` as return type which it doesn't support the zig error, but due to the current coding convention to handle the Result type:

``` zig
pub fn functions(
    // input params...
) Error!void {
    try maybeError( extern_fn_from_miniaudio(...));
}
```

This makes decoder has to explicitly handle the error in the callback function like shown:

``` zig
decoder.readPCMFrames(pOutput.?, frame_count, &frames_read) catch |err| {
    std.debug.print("ERROR: {any}", .{err});
    return;
};
```

I tried to change the return type of the callback function as `!void`, and trying to cast the function with pointer cast when I am creating the device like shown:

``` zig
device_config.data_callback = @ptrCast(&data_callback);
```

Despite the lack of compile error, the device can't trigger the callback at run time. Should we keep the explicit error handling in the callback function, or a better ways to handle error inside such functions?

In addition, since testing the decoder requires sample files to begin with, besides a separate project for testing the function externally, what kind of tests can be included within the library?