### PR TITLE
add: device playback information query methods

### DIFF
--- a/src/zaudio.c
+++ b/src/zaudio.c
@@ -458,6 +458,21 @@ void* zaudioDeviceGetUserData(ma_device* handle) {
     assert(handle != NULL);
     return handle->pUserData;
 }
+
+ma_uint32 zaudioDeviceGetSampleRate(ma_device* handle) {
+    assert(handle != NULL);
+    return handle->sampleRate;
+}
+
+ma_format zaudioDeviceGetPlaybackFormat(ma_device* handle) {
+    assert(handle != NULL);
+    return handle->playback.format;
+}
+
+ma_uint32 zaudioDeviceGetPlaybackChannels(ma_device* handle) {
+    assert(handle != NULL);
+    return handle->playback.channels;
+}
 //--------------------------------------------------------------------------------------------------
 void zaudioEngineConfigInit(ma_engine_config* out_config) {
     assert(out_config != NULL);

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -1976,6 +1976,15 @@ pub const Device = opaque {
     }
     extern fn ma_device_get_master_volume(device: *const Device, volume: *f32) Result;
 
+    pub const getSampleRate = zaudioDeviceGetSampleRate;
+    extern fn zaudioDeviceGetSampleRate(device: *const Device) u32;
+
+    pub const getPlaybackFormat = zaudioDeviceGetPlaybackFormat;
+    extern fn zaudioDeviceGetPlaybackFormat(device: *const Device) Format;
+
+    pub const getPlaybackChannels = zaudioDeviceGetPlaybackChannels;
+    extern fn zaudioDeviceGetPlaybackChannels(device: *const Device) u32;
+
     pub const Type = enum(c_int) {
         playback = 1,
         capture = 2,
@@ -3084,7 +3093,7 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
 
     const mem = mem_allocator.?.alignedAlloc(
         u8,
-        .fromByteUnits(mem_alignment),
+        @ctz(@as(usize, mem_alignment)),
         size,
     ) catch @panic("zaudio: out of memory");
 


### PR DESCRIPTION
When configurations such as sample rate and number of channels are left empty there is no way to query that information back after the device is initialized with system defaults. This PR adds these methods to `Device`:

```zig
fn getSampleRate(device: *const Device) u32 {}
fn getPlaybackFormat(device: *const Device) Format {}
fn getPlaybackChannels(device: *const Device) u32 {}
```

One quick fix on memory allocation on `zaudioMalloc` function to manually inlining `std.mem.Alignment.fromByteUnits` to keep this library backward compatible with zig v0.14.0