### PR TITLE
Update build for Zig 0.16

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,22 +22,22 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(miniaudio_lib);
 
     miniaudio.addIncludePath(b.path("libs/miniaudio"));
-    miniaudio_lib.linkLibC();
+    miniaudio.linkSystemLibrary("c", .{});
 
     if (target.result.os.tag == .macos) {
         if (b.lazyDependency("system_sdk", .{})) |system_sdk| {
-            miniaudio_lib.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
-            miniaudio_lib.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
-            miniaudio_lib.addLibraryPath(system_sdk.path("macos12/usr/lib"));
+            miniaudio.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
+            miniaudio.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
+            miniaudio.addLibraryPath(system_sdk.path("macos12/usr/lib"));
         }
-        miniaudio_lib.linkFramework("CoreAudio");
-        miniaudio_lib.linkFramework("CoreFoundation");
-        miniaudio_lib.linkFramework("AudioUnit");
-        miniaudio_lib.linkFramework("AudioToolbox");
+        miniaudio.linkFramework("CoreAudio", .{});
+        miniaudio.linkFramework("CoreFoundation", .{});
+        miniaudio.linkFramework("AudioUnit", .{});
+        miniaudio.linkFramework("AudioToolbox", .{});
     } else if (target.result.os.tag == .linux) {
-        miniaudio_lib.linkSystemLibrary("pthread");
-        miniaudio_lib.linkSystemLibrary("m");
-        miniaudio_lib.linkSystemLibrary("dl");
+        miniaudio.linkSystemLibrary("pthread", .{});
+        miniaudio.linkSystemLibrary("m", .{});
+        miniaudio.linkSystemLibrary("dl", .{});
     }
 
     miniaudio.addCSourceFile(.{
@@ -75,7 +75,7 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(tests);
 
-    tests.linkLibrary(miniaudio_lib);
+    tests.root_module.linkLibrary(miniaudio_lib);
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zaudio,
     .fingerprint = 0xc5244e8cd6bdcffc, // Changing this has security and trust implications.
     .version = "0.11.0-dev",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const assert = std.debug.assert;
+const mutex_io: std.Io = std.Io.Threaded.global_single_threaded.io();
 //--------------------------------------------------------------------------------------------------
 //
 // Misc
@@ -3157,14 +3158,14 @@ pub const Fence = opaque {
 //--------------------------------------------------------------------------------------------------
 var mem_allocator: ?std.mem.Allocator = null;
 var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
-var mem_mutex: std.Thread.Mutex = .{};
+var mem_mutex: std.Io.Mutex = .init;
 const mem_alignment = 16;
 
 extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    mem_mutex.lockUncancelable(mutex_io);
+    defer mem_mutex.unlock(mutex_io);
 
     const zig_version = @import("builtin").zig_version;
 
@@ -3187,8 +3188,8 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
 extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    mem_mutex.lockUncancelable(mutex_io);
+    defer mem_mutex.unlock(mutex_io);
 
     const old_size = if (ptr != null) mem_allocations.?.get(@intFromPtr(ptr.?)).? else 0;
     const old_mem = if (old_size > 0)
@@ -3212,8 +3213,8 @@ extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) ca
 
 fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
-        mem_mutex.lock();
-        defer mem_mutex.unlock();
+        mem_mutex.lockUncancelable(mutex_io);
+        defer mem_mutex.unlock(mutex_io);
 
         const size = mem_allocations.?.fetchRemove(@intFromPtr(ptr)).?.value;
         const mem = @as([*]align(mem_alignment) u8, @ptrCast(@alignCast(ptr)))[0..size];
@@ -3317,7 +3318,7 @@ test "zaudio.soundgroup.basic" {
 }
 
 test {
-    std.testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDecls(@This());
 }
 
 test "zaudio.fence.basic" {
@@ -3452,7 +3453,7 @@ test "zaudio.audio_buffer" {
     sound.setLooping(true);
     try sound.start();
 
-    std.Thread.sleep(1e8);
+    try std.Io.sleep(mutex_io, .fromNanoseconds(1e8), .awake);
 }
 
 test "zaudio.data_converter" {

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const assert = std.debug.assert;
-const mutex_io: std.Io = std.Io.Threaded.global_single_threaded.io();
 //--------------------------------------------------------------------------------------------------
 //
 // Misc
@@ -3164,8 +3163,8 @@ const mem_alignment = 16;
 extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lockUncancelable(mutex_io);
-    defer mem_mutex.unlock(mutex_io);
+    std.Io.Threaded.mutexLock(&mem_mutex);
+    defer std.Io.Threaded.mutexUnlock(&mem_mutex);
 
     const zig_version = @import("builtin").zig_version;
 
@@ -3188,8 +3187,8 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
 extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lockUncancelable(mutex_io);
-    defer mem_mutex.unlock(mutex_io);
+    std.Io.Threaded.mutexLock(&mem_mutex);
+    defer std.Io.Threaded.mutexUnlock(&mem_mutex);
 
     const old_size = if (ptr != null) mem_allocations.?.get(@intFromPtr(ptr.?)).? else 0;
     const old_mem = if (old_size > 0)
@@ -3213,8 +3212,8 @@ extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) ca
 
 fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
-        mem_mutex.lockUncancelable(mutex_io);
-        defer mem_mutex.unlock(mutex_io);
+        std.Io.Threaded.mutexLock(&mem_mutex);
+        defer std.Io.Threaded.mutexUnlock(&mem_mutex);
 
         const size = mem_allocations.?.fetchRemove(@intFromPtr(ptr)).?.value;
         const mem = @as([*]align(mem_alignment) u8, @ptrCast(@alignCast(ptr)))[0..size];
@@ -3453,7 +3452,7 @@ test "zaudio.audio_buffer" {
     sound.setLooping(true);
     try sound.start();
 
-    try std.Io.sleep(mutex_io, .fromNanoseconds(1e8), .awake);
+    try std.testing.io.sleep(.fromNanoseconds(1e8), .awake);
 }
 
 test "zaudio.data_converter" {


### PR DESCRIPTION
## Summary
- Update build linking calls for Zig 0.16's module-based build API
- Move the package minimum Zig version to `0.16.0`
- Replace removed std APIs used by tests and the allocator mutex

## Validation
- `zig build`
- `zig build test`