### PR TITLE
Migrated to zig 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore some special directories
 .zig-cache
 zig-out
+zig-pkg
 
 # Ignore some special OS files
 *.DS_Store

--- a/build.zig
+++ b/build.zig
@@ -22,22 +22,22 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(miniaudio_lib);
 
     miniaudio.addIncludePath(b.path("libs/miniaudio"));
-    miniaudio_lib.linkLibC();
+    miniaudio_lib.root_module.link_libc = true;
 
     if (target.result.os.tag == .macos) {
         if (b.lazyDependency("system_sdk", .{})) |system_sdk| {
-            miniaudio_lib.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
-            miniaudio_lib.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
-            miniaudio_lib.addLibraryPath(system_sdk.path("macos12/usr/lib"));
+            miniaudio_lib.root_module.addFrameworkPath(system_sdk.path("macos12/System/Library/Frameworks"));
+            miniaudio_lib.root_module.addSystemIncludePath(system_sdk.path("macos12/usr/include"));
+            miniaudio_lib.root_module.addLibraryPath(system_sdk.path("macos12/usr/lib"));
         }
-        miniaudio_lib.linkFramework("CoreAudio");
-        miniaudio_lib.linkFramework("CoreFoundation");
-        miniaudio_lib.linkFramework("AudioUnit");
-        miniaudio_lib.linkFramework("AudioToolbox");
+        miniaudio_lib.root_module.linkFramework("CoreAudio", .{});
+        miniaudio_lib.root_module.linkFramework("CoreFoundation", .{});
+        miniaudio_lib.root_module.linkFramework("AudioUnit", .{});
+        miniaudio_lib.root_module.linkFramework("AudioToolbox", .{});
     } else if (target.result.os.tag == .linux) {
-        miniaudio_lib.linkSystemLibrary("pthread");
-        miniaudio_lib.linkSystemLibrary("m");
-        miniaudio_lib.linkSystemLibrary("dl");
+        miniaudio_lib.root_module.linkSystemLibrary("pthread", .{});
+        miniaudio_lib.root_module.linkSystemLibrary("m", .{});
+        miniaudio_lib.root_module.linkSystemLibrary("dl", .{});
     }
 
     miniaudio.addCSourceFile(.{
@@ -75,7 +75,7 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(tests);
 
-    tests.linkLibrary(miniaudio_lib);
+    tests.root_module.linkLibrary(miniaudio_lib);
 
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -3157,14 +3157,17 @@ pub const Fence = opaque {
 //--------------------------------------------------------------------------------------------------
 var mem_allocator: ?std.mem.Allocator = null;
 var mem_allocations: ?std.AutoHashMap(usize, usize) = null;
-var mem_mutex: std.Thread.Mutex = .{};
+var mem_mutex: std.Io.Mutex = std.mem.zeroInit(std.Io.Mutex, .{});
 const mem_alignment = 16;
+
+var io_threaded: std.Io.Threaded = .init_single_threaded;
+var io: std.Io = io_threaded.io();
 
 extern var zaudioMallocPtr: ?*const fn (size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    mem_mutex.lock(io) catch unreachable;
+    defer mem_mutex.unlock(io);
 
     const zig_version = @import("builtin").zig_version;
 
@@ -3187,8 +3190,8 @@ fn zaudioMalloc(size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
 extern var zaudioReallocPtr: ?*const fn (ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque;
 
 fn zaudioRealloc(ptr: ?*anyopaque, size: usize, _: ?*anyopaque) callconv(.c) ?*anyopaque {
-    mem_mutex.lock();
-    defer mem_mutex.unlock();
+    mem_mutex.lock(io) catch unreachable;
+    defer mem_mutex.unlock(io);
 
     const old_size = if (ptr != null) mem_allocations.?.get(@intFromPtr(ptr.?)).? else 0;
     const old_mem = if (old_size > 0)
@@ -3212,8 +3215,8 @@ extern var zaudioFreePtr: ?*const fn (maybe_ptr: ?*anyopaque, _: ?*anyopaque) ca
 
 fn zaudioFree(maybe_ptr: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
     if (maybe_ptr) |ptr| {
-        mem_mutex.lock();
-        defer mem_mutex.unlock();
+        mem_mutex.lock(io) catch unreachable;
+        defer mem_mutex.unlock(io);
 
         const size = mem_allocations.?.fetchRemove(@intFromPtr(ptr)).?.value;
         const mem = @as([*]align(mem_alignment) u8, @ptrCast(@alignCast(ptr)))[0..size];
@@ -3314,10 +3317,6 @@ test "zaudio.soundgroup.basic" {
             return err;
         };
     }
-}
-
-test {
-    std.testing.refAllDeclsRecursive(@This());
 }
 
 test "zaudio.fence.basic" {
@@ -3452,7 +3451,7 @@ test "zaudio.audio_buffer" {
     sound.setLooping(true);
     try sound.start();
 
-    std.Thread.sleep(1e8);
+    try std.Io.sleep(io, .fromNanoseconds(1e8), .real);
 }
 
 test "zaudio.data_converter" {


### PR DESCRIPTION
Replaced deprecated functions from 0.15 with new ones for 0.16.

- Replaced Thread.Mutex with Std.Io.Mutex
- Replaced Thread.sleep with td.Io.sleep

I don't know if this is wanted or needed, but this is the fork i made for my project. If it is ever needed, it will be right here. I have tested this and it works.