### PR TITLE
Append zig-pkg path into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignore some special directories
 .zig-cache
 zig-out
+zig-pkg
 
 # Ignore some special OS files
 *.DS_Store


### PR DESCRIPTION
## Summary
- Append `zig-pkg` path into `.gitignore` file.
  - Because zig 0.16.0 uses `zig-pkg` directory for caching dependencies.
  - The updating of zig have done via #18.

## Validation
- `zig build`
- `zig build test`