### PR TITLE
Added getTimeInMilliseconds for zaudio.Sound

### DIFF
--- a/src/zaudio.zig
+++ b/src/zaudio.zig
@@ -2742,6 +2742,9 @@ pub const Sound = opaque {
     pub const getTimeInPcmFrames = ma_sound_get_time_in_pcm_frames;
     extern fn ma_sound_get_time_in_pcm_frames(sound: *const Sound) u64;
 
+    pub const getTimeInMilliseconds = ma_sound_get_time_in_milliseconds;
+    extern fn ma_sound_get_time_in_milliseconds(sound: *const Sound) u64;
+
     pub fn setLooping(sound: *Sound, looping: bool) void {
         ma_sound_set_looping(sound, if (looping) .true32 else .false32);
     }


### PR DESCRIPTION
Hey!

I think this binding was missing and I needed it in my code, so I added it.

Thanks for your work guys!